### PR TITLE
Simple fix for github issue #3

### DIFF
--- a/cmds.c
+++ b/cmds.c
@@ -3530,6 +3530,12 @@ cleanup:
 	if (ecl || ecr || ec)
 		cr = CMD_ERR_GET;
 
+	if (ec  && strncmp(ec_get_errmsg(ec), "550 File exists", 15) == 0 ||
+	    ecr && strncmp(ec_get_errmsg(ecr),"550 File exists", 15) == 0)
+	{
+	    delfile=0;
+	}
+
 	ec_print(ec);
 	ec_destroy(ec);
 

--- a/cmds.c
+++ b/cmds.c
@@ -3530,8 +3530,8 @@ cleanup:
 	if (ecl || ecr || ec)
 		cr = CMD_ERR_GET;
 
-	if (ec  && strncmp(ec_get_errmsg(ec), "550 File exists", 15) == 0 ||
-	    ecr && strncmp(ec_get_errmsg(ecr),"550 File exists", 15) == 0)
+	if (ec  && strncmp(ec_get_errmsg(ec), "550 ", 4) == 0 ||
+	    ecr && strncmp(ec_get_errmsg(ecr),"550 ", 4) == 0)
 	{
 	    delfile=0;
 	}

--- a/errcode.c
+++ b/errcode.c
@@ -190,6 +190,11 @@ ec_destroy(errcode_t errcode)
 	return;
 }
 
+char
+*ec_get_errmsg(errcode_t errcode)
+{
+    return (errcode ? *(errcode->errmsg) : "");
+}
 
 void
 ec_print(errcode_t errcode)

--- a/errcode.h
+++ b/errcode.h
@@ -52,6 +52,9 @@
 
 typedef struct errcode_s * errcode_t;
 
+char *
+ec_get_errmsg(errcode_t errcode);
+
 errcode_t
 ec_create(OM_uint32, OM_uint32, char * fmt, ...);
 


### PR DESCRIPTION
This is a simple and not very clean fix for
gridcf/UberFTP/issues/3
Either (one of) the `l_write()` or the `l_close()` can fail if the remote file
already exists, since the data goes over a different channel than the control
messages. For large files, it will typically be one of the later `l_write()`
statements, for small files probably the `l_close()`. Hence we effectively only
have the `errmsg` to find out what happened, and therefore do a simple `str(n)cmp`
with this `errmsg`. For this we also need to add a function to get it from the
opaque `errcode_t`.
Note that there are other FTP error codes that probably should prevent the delete.
Feedback on this would be highly appreciated (-;