### PR TITLE
Updated email address and notes

### DIFF
--- a/cmds.c
+++ b/cmds.c
@@ -1384,7 +1384,7 @@ static cmdret_t
 _c_bugs()
 {
 	o_printf(DEBUG_ERRS_ONLY, 
-	    "For feature requests or bug reporting, email gridftp@ncsa.uiuc.edu\n");
+	    "For feature requests or bug reporting, email discuss@gridcf.org\n");
 	return CMD_SUCCESS;
 }
 

--- a/mssftp.1
+++ b/mssftp.1
@@ -1,5 +1,5 @@
 .\" @(#)mssftp.1c 1.34 90/02/15 SMI; from UCB 4.3
-.TH MSSFTP 1C "20 Aug 2020"
+.TH MSSFTP 1C "12 Nov 2020"
 .SH NAME
 mssftp \- File transfer program for NCSA's mass storage system
 .SH SYNOPSIS
@@ -666,6 +666,6 @@ Active vs. Passive FTP:
 .br
   http://slacksite.com/other/ftp.html
 
-\fBNote: The links above are not under NCSA's control
+\fBNote: The links above are not under the GridCF's control
 so they may become obsolete.\fR
 

--- a/uberftp.1
+++ b/uberftp.1
@@ -1,5 +1,5 @@
 .\" @(#)uberftp.1c 1.34 90/02/15 SMI; from UCB 4.3
-.TH UBERFTP 1C "20 Aug 2020"
+.TH UBERFTP 1C "12 Nov 2020"
 .SH NAME
 uberftp \- GridFTP-enabled client
 .SH SYNOPSIS
@@ -847,6 +847,6 @@ Active vs. Passive FTP:
 .br
   http://slacksite.com/other/ftp.html
 
-\fBNote: The links above are not under NCSA's control 
+\fBNote: The links above are not under the GridCF's control
 so they may become obsolete.\fR
 


### PR DESCRIPTION
This changes the email address that is printed by UberFTP when using the `bugs` command to the GridCF's discuss mailing list and also updates two notes in the manpages. The latter because the prior URL changes were also made by us, so it makes more sense to name the GridCF in these notes instead of NCSA.

****

When merged, I propose to tag this as `Version_2_9_Beta1`.